### PR TITLE
make old binary a hidden file on windows since it can't be easily deleted

### DIFF
--- a/hideFileStub.go
+++ b/hideFileStub.go
@@ -1,0 +1,7 @@
+// +build !windows
+
+package update
+
+func hideWindowsFile(s string) error {
+	return nil
+}

--- a/update.go
+++ b/update.go
@@ -29,14 +29,13 @@ download progress,
 package update
 
 import (
+	"bitbucket.org/kardianos/osext"
 	"compress/gzip"
 	"fmt"
-	"bitbucket.org/kardianos/osext"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 )
@@ -138,7 +137,7 @@ func NewDownload(url string) *Download {
 		HttpClient: new(http.Client),
 		Progress:   make(chan int),
 		Method:     "GET",
-		Url: url,
+		Url:        url,
 	}
 }
 
@@ -414,10 +413,7 @@ func FromStream(newBinary io.Reader) (err error, errRecover error) {
 		return
 	}
 
-	//for windows, make old executable hidden
-	if runtime.GOOS == "windows" {
-		_ = exec.Command("attrib", "+H", oldExecPath).Run()
-	}
+	_ = hideWindowsFile(oldExecPath)
 
 	// move the new exectuable in to become the new program
 	err = os.Rename(newExecPath, thisExecPath)

--- a/update_windows.go
+++ b/update_windows.go
@@ -1,0 +1,19 @@
+package update
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+func hideWindowsFile(oldExecPath string) error {
+	kernel32 := syscall.NewLazyDLL("kernel32.dll")
+	setFileAttributes := kernel32.NewProc("SetFileAttributesW")
+
+	r1, _, err := setFileAttributes.Call(uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(oldExecPath))), 2)
+
+	if r1 == 0 {
+		return err
+	} else {
+		return nil
+	}
+}


### PR DESCRIPTION
A quick attempt to fix #1.  Hiding the file seems a good enough solution compared to the hoops you have to jump through to actually delete it.
