### PR TITLE
Replaces url to godoc.org with badge in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Updating your program to a new version is as easy as:
 
 Comprehensive API documentation and code examples are available in the code documentation available on godoc.org:
 
-### [https://godoc.org/github.com/inconshreveable/go-update](https://godoc.org/github.com/inconshreveable/go-update)
+[![GoDoc](https://godoc.org/github.com/inconshreveable/go-update?status.svg)](https://godoc.org/github.com/inconshreveable/go-update)
 
 ## Features
 


### PR DESCRIPTION
It's easier to see in the readme and a more standaridzed way of linking to the documentation.
