### PR TITLE
Mode bits

### DIFF
--- a/update.go
+++ b/update.go
@@ -128,6 +128,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"syscall"
 )
 
 // The type of a binary patch, if any. Only bsdiff is supported
@@ -356,6 +357,10 @@ func (u *Update) FromStream(updateWith io.Reader) (err error, errRecover error) 
 	}
 	fileMode := fi.Mode()
 
+	// set umask to 0 so that we can set mode bits properly
+	oldMode := syscall.Umask(0000)
+	defer syscall.Umask(oldMode)
+
 	// Copy the contents of the new binary to the new executable file
 	newPath := filepath.Join(updateDir, fmt.Sprintf(".%s.new", filename))
 	fp, err := os.OpenFile(newPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, fileMode)
@@ -421,6 +426,10 @@ func (u *Update) CanUpdate() (err error) {
 		return
 	}
 	fileMode := fi.Mode()
+
+	// set umask to 0 so that we can set mode bits properly
+	oldMode := syscall.Umask(0000)
+	defer syscall.Umask(oldMode)
 
 	// attempt to open a file in the file's directory
 	newPath := filepath.Join(fileDir, fmt.Sprintf(".%s.new", fileName))

--- a/update.go
+++ b/update.go
@@ -181,7 +181,7 @@ func New() *Update {
 }
 
 // Target configures the update to update the file at the given path.
-// The emptry string means 'the executable file of the running program'.
+// The empty string means 'the executable file of the running program'.
 func (u *Update) Target(path string) *Update {
 	u.TargetPath = path
 	return u
@@ -196,7 +196,7 @@ func (u *Update) ApplyPatch(patchType PatchType) *Update {
 }
 
 // VerifyChecksum configures the update to verify that the
-// the update has the given sha256 checksum.
+// update has the given sha256 checksum.
 func (u *Update) VerifyChecksum(checksum []byte) *Update {
 	u.Checksum = checksum
 	return u
@@ -383,7 +383,7 @@ func (u *Update) FromStream(updateWith io.Reader) (err error, errRecover error) 
 		return
 	}
 
-	// move the new exectuable in to become the new program
+	// move the new executable in to become the new program
 	err = os.Rename(newPath, updatePath)
 
 	if err != nil {

--- a/update.go
+++ b/update.go
@@ -282,7 +282,7 @@ func (u *Update) FromFile(path string) (err error, errRecover error) {
 //
 // 3. If configured, verifies the RSA signature with a public key.
 //
-// 4. Creates a new file, /path/to/.target.new with mode 0755 with the contents of the updated file
+// 4. Creates a new file, /path/to/.target.new with the same mode bits and contents of the updated file
 //
 // 5. Renames /path/to/target to /path/to/.target.old
 //
@@ -349,9 +349,16 @@ func (u *Update) FromStream(updateWith io.Reader) (err error, errRecover error) 
 	updateDir := filepath.Dir(updatePath)
 	filename := filepath.Base(updatePath)
 
-	// Copy the contents of of newbinary to a the new executable file
+	// read mode bits from old file
+	fi, err := os.Stat(updatePath)
+	if err != nil {
+		return
+	}
+	fileMode := fi.Mode()
+
+	// Copy the contents of the new binary to the new executable file
 	newPath := filepath.Join(updateDir, fmt.Sprintf(".%s.new", filename))
-	fp, err := os.OpenFile(newPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+	fp, err := os.OpenFile(newPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, fileMode)
 	if err != nil {
 		return
 	}
@@ -408,9 +415,16 @@ func (u *Update) CanUpdate() (err error) {
 	fileDir := filepath.Dir(path)
 	fileName := filepath.Base(path)
 
+	// read mode bits from old file
+	fi, err := os.Stat(path)
+	if err != nil {
+		return
+	}
+	fileMode := fi.Mode()
+
 	// attempt to open a file in the file's directory
 	newPath := filepath.Join(fileDir, fmt.Sprintf(".%s.new", fileName))
-	fp, err := os.OpenFile(newPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+	fp, err := os.OpenFile(newPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, fileMode)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
I was surprised to see that updated files are always created using mode bits `0755`. I would like to update non-executable files such as config files, style sheets, etc. Having these files marked as executables isn't a huge deal, but there may be other situations where clobbering the mode bits has unintended consequences.

To address this, I modified `FromStream` and `CanUpdate` to reuse the mode bits of the old file when creating the updated file. I've tested this with my own program and it appears to work as intended, though I can add a test case for it if necessary.

One implication of this that I haven't fully thought through is with regard to `PatchType` -- specifically, if the mode bits will affect binary patching. A quick scan of the patching code doesn't seem to reveal any issues, but I haven't personally tested it yet.