### PR TITLE
bitbucket.org/kardianos/osext has moved to github.com/kardianos/osext

### DIFF
--- a/check/check.go
+++ b/check/check.go
@@ -10,8 +10,8 @@ import (
 	"net/http"
 	"runtime"
 
-	"bitbucket.org/kardianos/osext"
 	"github.com/inconshreveable/go-update"
+	"github.com/kardianos/osext"
 )
 
 type Initiative string

--- a/update.go
+++ b/update.go
@@ -113,7 +113,6 @@ while outputting a progress meter and supports resuming partial downloads.
 package update
 
 import (
-	"bitbucket.org/kardianos/osext"
 	"bytes"
 	"crypto"
 	"crypto/rsa"
@@ -122,12 +121,14 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"github.com/inconshreveable/go-update/download"
-	"github.com/kr/binarydist"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/inconshreveable/go-update/download"
+	"github.com/kardianos/osext"
+	"github.com/kr/binarydist"
 )
 
 // The type of a binary patch, if any. Only bsdiff is supported


### PR DESCRIPTION
A change to bitbucket.org/kardianos/osext was pushed today that enforces the canonical import to be github.com/kardianos/osext

and goimports rearranged a few things.