### PR TITLE
Fixing osext import path

### DIFF
--- a/check/check.go
+++ b/check/check.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"runtime"
 
-	"bitbucket.org/kardianos/osext"
+	"github.com/kardianos/osext"
 	"github.com/inconshreveable/go-update"
 )
 

--- a/update.go
+++ b/update.go
@@ -113,7 +113,7 @@ while outputting a progress meter and supports resuming partial downloads.
 package update
 
 import (
-	"bitbucket.org/kardianos/osext"
+	"github.com/kardianos/osext"
 	"bytes"
 	"crypto"
 	"crypto/rsa"


### PR DESCRIPTION
Its moved from bitbucket to github on 22. of febr
see: https://bitbucket.org/kardianos/osext/src/816c96ec6fef6a0cd72c9395d192c4bd0d918753/osext.go?at=default#cl-6