### PR TITLE
Update can now be constructed with an HTTPClient

### DIFF
--- a/download/download.go
+++ b/download/download.go
@@ -49,9 +49,9 @@ type Download struct {
 
 // New initializes a new Download object which will download
 // the content from url into target.
-func New(url string, target Target) *Download {
+func New(url string, target Target, httpClient *http.Client) *Download {
 	return &Download{
-		HttpClient: new(http.Client),
+		HttpClient: httpClient,
 		Progress:   make(chan int),
 		Method:     "GET",
 		Url:        url,
@@ -81,6 +81,11 @@ func (d *Download) Get() (err error) {
 	req, err := http.NewRequest(d.Method, d.Url, nil)
 	if err != nil {
 		return
+	}
+
+	// create an http client if one does not exist
+	if d.HttpClient == nil {
+		d.HttpClient = http.DefaultClient
 	}
 
 	// we have to add headers like this so they get used across redirects

--- a/update.go
+++ b/update.go
@@ -123,6 +123,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"path/filepath"
 
@@ -154,6 +155,9 @@ type Update struct {
 
 	// signature to use for signature verification
 	Signature []byte
+
+	// configurable http client can be passed to download
+	HTTPClient *http.Client
 }
 
 func (u *Update) getPath() (string, error) {
@@ -252,7 +256,7 @@ func (u *Update) VerifySignatureWithPEM(publicKeyPEM []byte) (*Update, error) {
 // FromUrl updates the target with the contents of the given URL.
 func (u *Update) FromUrl(url string) (err error, errRecover error) {
 	target := new(download.MemoryTarget)
-	err = download.New(url, target).Get()
+	err = download.New(url, target, u.HTTPClient).Get()
 	if err != nil {
 		return
 	}

--- a/update.go
+++ b/update.go
@@ -127,9 +127,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/inconshreveable/go-update/download"
 	"github.com/kardianos/osext"
 	"github.com/kr/binarydist"
+	"github.com/zachgersh/go-update/download"
 )
 
 // The type of a binary patch, if any. Only bsdiff is supported


### PR DESCRIPTION
Had a particular need to pass this a client that is insecure.  Wrote a corresponding test for it and left the default no client case alone.