### PR TITLE
use custom httpclient from updater for check

### DIFF
--- a/check/check.go
+++ b/check/check.go
@@ -113,7 +113,13 @@ func (p *Params) CheckForUpdate(url string, up *update.Update) (*Result, error) 
 		return nil, err
 	}
 
-	resp, err := http.Post(url, "application/json", bytes.NewReader(body))
+	client := up.HTTPClient
+
+	if client == nil {
+		client = &http.Client{}
+	}
+
+	resp, err := client.Post(url, "application/json", bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
If the users sets a custom `HTTPClient` for the updater this pull request makes the `check` package use it as well.