### PR TITLE
KeepOld and OldPath options

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -107,7 +107,6 @@ func Apply(update io.Reader, opts *Options) error {
 	if err != nil {
 		return err
 	}
-	defer fp.Close()
 	_, err = io.Copy(fp, bytes.NewReader(newBytes))
 
 	// if we don't call fp.Close(), windows won't let us move the new executable
@@ -115,7 +114,10 @@ func Apply(update io.Reader, opts *Options) error {
 	fp.Close()
 
 	// this is where we'll move the executable to so that we can swap in the updated replacement
-	oldPath := filepath.Join(updateDir, fmt.Sprintf(".%s.old", filename))
+	oldPath := opts.OldPath
+	if oldPath == "" {
+		oldPath = filepath.Join(updateDir, fmt.Sprintf(".%s.old", filename))
+	}
 
 	// delete any existing old exec file - this is necessary on Windows for two reasons:
 	// 1. after a successful update, Windows can't remove the .old file because the process is still running
@@ -148,11 +150,13 @@ func Apply(update io.Reader, opts *Options) error {
 	}
 
 	// move successful, remove the old binary
-	errRemove := os.Remove(oldPath)
+	if !opts.KeepOld {
+		errRemove := os.Remove(oldPath)
 
-	// windows has trouble with removing old binaries, so hide it instead
-	if errRemove != nil {
-		_ = hideFile(oldPath)
+		// windows has trouble with removing old binaries, so hide it instead
+		if errRemove != nil {
+			_ = hideFile(oldPath)
+		}
 	}
 
 	return nil
@@ -205,6 +209,13 @@ type Options struct {
 	// If nil, treat the update as a complete replacement for the contents of the file at TargetPath.
 	// If non-nil, treat the update contents as a patch and use this object to apply the patch.
 	Patcher Patcher
+
+	// If true, keep the old executable
+	// If false, remove the old executable after update (default)
+	KeepOld bool
+
+	//OldPath defines the path where the old executable is stored after update
+	OldPath string
 }
 
 // CheckPermissions determines whether the process has the correct permissions to

--- a/apply.go
+++ b/apply.go
@@ -114,7 +114,7 @@ func Apply(update io.Reader, opts *Options) error {
 	fp.Close()
 
 	// this is where we'll move the executable to so that we can swap in the updated replacement
-	oldPath := opts.OldPath
+	oldPath := opts.OldSavePath
 	if oldPath == "" {
 		oldPath = filepath.Join(updateDir, fmt.Sprintf(".%s.old", filename))
 	}
@@ -149,8 +149,8 @@ func Apply(update io.Reader, opts *Options) error {
 		return err
 	}
 
-	// move successful, remove the old binary
-	if !opts.KeepOld {
+	// move successful, remove the old binary if needed
+	if opts.OldSavePath == "" {
 		errRemove := os.Remove(oldPath)
 
 		// windows has trouble with removing old binaries, so hide it instead
@@ -210,12 +210,9 @@ type Options struct {
 	// If non-nil, treat the update contents as a patch and use this object to apply the patch.
 	Patcher Patcher
 
-	// If true, keep the old executable
-	// If false, remove the old executable after update (default)
-	KeepOld bool
-
 	//OldPath defines the path where the old executable is stored after update
-	OldPath string
+	//If set to empty string old executable is removed after update(default)
+	OldSavePath string
 }
 
 // CheckPermissions determines whether the process has the correct permissions to

--- a/apply_test.go
+++ b/apply_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/pem"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -60,41 +59,18 @@ func TestApplySimple(t *testing.T) {
 	validateUpdate(fName, err, t)
 }
 
-func TestApplyKeepOld(t *testing.T) {
+func TestApplyOldSavePath(t *testing.T) {
 	t.Parallel()
 
-	fName := "TestApplyKeepOld"
+	fName := "TestApplyOldSavePath"
 	defer cleanup(fName)
 	writeOldFile(fName, t)
 
-	err := Apply(bytes.NewReader(newFile), &Options{
-		TargetPath: fName,
-		KeepOld:    true,
-	})
-	validateUpdate(fName, err, t)
-
-	oldfName := fmt.Sprintf(".%s.old", fName)
-
-	if _, err := os.Stat(oldfName); os.IsNotExist(err) {
-		t.Fatalf("Failed to find the old file: %v", err)
-	}
-
-	cleanup(oldfName)
-}
-
-func TestApplyKeepOldPath(t *testing.T) {
-	t.Parallel()
-
-	fName := "TestApplyKeepOldPath"
-	defer cleanup(fName)
-	writeOldFile(fName, t)
-
-	oldfName := "OldTestApplyKeepOldPath"
+	oldfName := "OldSavePath"
 
 	err := Apply(bytes.NewReader(newFile), &Options{
-		TargetPath: fName,
-		KeepOld:    true,
-		OldPath:    oldfName,
+		TargetPath:  fName,
+		OldSavePath: oldfName,
 	})
 	validateUpdate(fName, err, t)
 


### PR DESCRIPTION
Sometimes it's necessary to keep an old executable after update for emergency purposes.
In my case there are dozens of terminals that have really poor 2g internet connection. So rollback to previous version is very painful unless you have an old executable.

So I added these two options which are disabled by default.