### PR TITLE
Set correct permissions for new file

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -111,6 +111,7 @@ func Apply(update io.Reader, opts Options) error {
 	if err != nil {
 		return err
 	}
+	os.Chmod(newPath,opts.TargetMode)
 	defer fp.Close()
 
 	_, err = io.Copy(fp, bytes.NewReader(newBytes))

--- a/apply.go
+++ b/apply.go
@@ -111,7 +111,7 @@ func Apply(update io.Reader, opts Options) error {
 	if err != nil {
 		return err
 	}
-	os.Chmod(newPath,opts.TargetMode)
+	os.Chmod(newPath, opts.TargetMode)
 	defer fp.Close()
 
 	_, err = io.Copy(fp, bytes.NewReader(newBytes))


### PR DESCRIPTION
Using os.Chmod() applies the correct permissions to the newly created file (without modifications by the umask)
Fixes Issue #35 