### PR TITLE
Fixed file loss when power off

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -117,7 +117,8 @@ func Apply(update io.Reader, opts Options) error {
 	if err != nil {
 		return err
 	}
-
+	//don't call fp.Sync().system power off ,file will lost
+	fp.Sync()
 	// if we don't call fp.Close(), windows won't let us move the new executable
 	// because the file will still be "in use"
 	fp.Close()


### PR DESCRIPTION
文件系统可能不是立即保存到存储设备，如果在未保存到存储设备之前断电文件将丢失